### PR TITLE
build: use is-ci before husky install & syntax error in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apk add --no-cache python3 make gcc g++ libc-dev sqlite-dev
 
 COPY . /server-build
 
+ENV CI=true
+
 RUN npm i -g npm@8.7.0
 RUN npm ci --build-from-source --sqlite=/usr/local
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache python3 make gcc g++ libc-dev sqlite-dev
 COPY . /server-build
 
 RUN npm i -g npm@8.7.0
-RUN npm ci --production --build-from-source --sqlite=/usr/local
+RUN npm ci --build-from-source --sqlite=/usr/local
 
 # ---- RUNTIME IMAGE ----------------------------------------------------------
 FROM node:16.4-alpine

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-cat << "EOF"
+cat << "EOL"
 -------------------------------------
        ______              ___
       / ____/__  _________/ (_)_  ______ ___
@@ -14,7 +14,7 @@ cat << "EOF"
     ___/ /  __/ /   | |/ /  __/ /
    /____/\___/_/    |___/\___/_/
 Brought to you by ferdium.org
-EOF
+EOL
 
 key_file="${DATA_DIR}/FERDIUM_APP_KEY.txt"
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-cat << EOL
+cat << "EOF"
 -------------------------------------
        ______              ___
       / ____/__  _________/ (_)_  ______ ___
@@ -14,7 +14,7 @@ cat << EOL
     ___/ /  __/ /   | |/ /  __/ /
    /____/\___/_/    |___/\___/_/
 Brought to you by ferdium.org
-EOL
+EOF
 
 key_file="${DATA_DIR}/FERDIUM_APP_KEY.txt"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "eslint-config-airbnb-base": "^14.2.1",
         "eslint-plugin-import": "^2.23.4",
         "husky": "^7.0.1",
+        "is-ci": "3.0.1",
         "prettier": "2.3.2"
       },
       "engines": {
@@ -2200,6 +2201,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "node_modules/ci-info": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
+      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
+      "dev": true
     },
     "node_modules/class-utils": {
       "version": "0.3.6",
@@ -4491,6 +4498,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dev": true,
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
       }
     },
     "node_modules/is-core-module": {
@@ -11318,6 +11337,12 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
+    "ci-info": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
+      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
+      "dev": true
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -13123,6 +13148,15 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
       "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+    },
+    "is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dev": true,
+      "requires": {
+        "ci-info": "^3.2.0"
+      }
     },
     "is-core-module": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "8.7.0"
   },
   "scripts": {
-    "prepare": "node -e \"if (process.env.NODE_ENV !== 'production'){process.exit(1)} \" || husky install",
+    "prepare": "is-ci || husky install",
     "start": "node server.js",
     "test": "node ace test",
     "lint": "eslint \"{app,public,start}/**/*.js\" --quiet --fix"
@@ -53,6 +53,7 @@
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.23.4",
     "husky": "^7.0.1",
+    "is-ci": "3.0.1",
     "prettier": "2.3.2"
   },
   "autoload": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "8.7.0"
   },
   "scripts": {
-    "prepare": "husky install",
+    "prepare": "node -e \"if (process.env.NODE_ENV !== 'production'){process.exit(1)} \" || husky install",
     "start": "node server.js",
     "test": "node ace test",
     "lint": "eslint \"{app,public,start}/**/*.js\" --quiet --fix"


### PR DESCRIPTION
entrypoint.sh was a simple fix.  It was a syntax error with the EOF token.

DISCLAIMER:  I AM NOT A NODEJS PERSON.

"husky" is specified in packages.json as a devDependency. yet the Dockerfile is running npm ci with "--production".

With this modification, "husky install" will only be run if the NODE_ENV variable is NOT "production".

I have no idea if this is truly the proper way to resolve this issue for all build use-cases, but now it builds and the resulting container functions properly from my minimal testing (account creation via Ferdium, basic operation).