### PR TITLE
Add dynamic version of pnpm and npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ RUN apk add --no-cache python3 make gcc g++ libc-dev sqlite-dev
 COPY . /server-build
 
 ENV CI=true
-
-RUN npm i -g npm@8.7.0
+RUN NPM_VERSION=$(node -p 'require("./package.json").engines.npm'); npm i -g npm@$NPM_VERSION
 RUN npm ci --build-from-source --sqlite=/usr/local
 
 # ---- RUNTIME IMAGE ----------------------------------------------------------

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -17,8 +17,6 @@ Brought to you by ferdium.org
 EOL
 
 # Update recipes from official git repository
-npm i -gf pnpm@7.1.2
-
 if [ ! -d "/app/recipes/.git" ]; # When we mount an existing volume (ferdium-recipes-vol:/app/recipes) if this is only /app/recipes it is always true
 then
   echo '**** Generating recipes for first run ****'
@@ -35,6 +33,8 @@ fi
 
 cd recipes
 git config --global --add safe.directory /app/recipes
+EXPECTED_PNPM_VERSION=$(node -p 'require("./package.json").engines.pnpm')
+npm i -gf pnpm@$EXPECTED_PNPM_VERSION
 pnpm i
 pnpm package
 cd ..


### PR DESCRIPTION
Add dynamic version of pnpm and npm to solve a problem on the server whenever this dependencies are upgraded on the recipes repo (for the pnpm). This provided a problem on the server side, that would break and wouldn't do `pnpm i` given the version mismatch.

This should only be merged when #38 is merged, so that everything goes smoothly.