### PR TITLE
Fix gh actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,12 +43,7 @@ jobs:
             git push origin main --no-verify
             git tag -f $TAG_NAME
             git push origin --tags --no-verify
-
-            git checkout main
           fi
-
-          echo "Merge with fast-forward from 'origin/main'"
-          git merge --ff-only origin/main --no-verify
 
           echo "Number of changes: $CHANGES_COUNT"
           if [ $CHANGES_COUNT -eq 0 ] && [ $MANUAL_REBUILD != "true" ]; then

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,6 +92,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
+        if: ${{ (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[main]')) }}
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - 'main'
-    tags:
-    - 'v*'
 
 jobs:
   docker:
@@ -14,6 +12,52 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
+      - 
+        name: Check whether there are any commits since this run was last triggered and push them and/or set the output
+        id: should_run
+        if: ${{ (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[main]')) }}
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+          # Defensive: update submodules in the main branch
+          git checkout main
+          git submodule update --init --recursive --remote --rebase --force
+          git add .
+          git commit -am "Update submodules [skip ci]" --no-verify || true
+          git push origin main --no-verify
+          git checkout -
+
+          git submodule update --init --recursive --remote --rebase --force
+
+          CHANGES_COUNT=$(git diff --shortstat origin/main | wc -l)
+          MANUAL_REBUILD="${{ github.event_name == 'workflow_dispatch' }}"
+          VERSION_BUMP="${{ contains(github.event.inputs.message, '[version bump]') }}"
+          if [ $CHANGES_COUNT -gt 0 ] || [[ $MANUAL_REBUILD == "true" && $VERSION_BUMP == "true" ]]; then
+            # Do the version bump in the 'main' branch ONLY if
+            #   there were other changes coming from the 'main' branch (or)
+            #   this is a manual trigger with the key-phrase
+            git checkout main
+            TAG_NAME=$(npm version -m "%s [skip ci]" patch)
+            git commit --all --amend --no-edit --no-verify
+            git push origin main --no-verify
+            git tag -f $TAG_NAME
+            git push origin --tags --no-verify
+
+            git checkout main
+          fi
+
+          echo "Merge with fast-forward from 'origin/main'"
+          git merge --ff-only origin/main --no-verify
+
+          echo "Number of changes: $CHANGES_COUNT"
+          if [ $CHANGES_COUNT -eq 0 ] && [ $MANUAL_REBUILD != "true" ]; then
+            echo "No changes found - terminating the build"
+            echo "::set-output name=should_run::false"
+          else   # changes > 0 (or) MANUAL_REBUILD=true
+            echo "Pushing rebased commits"
+            git push origin $(git rev-parse --abbrev-ref HEAD) --no-verify
+          fi
       -
         name: Docker meta
         id: meta

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ferdium-server",
-  "version": "1.3.2",
+  "version": "1.3.6",
   "adonis-version": "4.1.0",
   "description": "Ferdium server to replace the default Franz/Ferdi server.",
   "main": "index.js",


### PR DESCRIPTION
Currently, there is no automatic version bump. Also, GH actions is being run for every commit pushed onto "main" branch, which is not intended... It should only run when a manual workflow is triggered.