### PR TITLE
fix: correctly map serviceIds during service/workspace import

### DIFF
--- a/app/Controllers/Http/DashboardController.js
+++ b/app/Controllers/Http/DashboardController.js
@@ -257,7 +257,7 @@ class DashboardController {
           settings: JSON.stringify(service.settings),
         });
 
-        serviceIdTranslation[service.id] = serviceId;
+        serviceIdTranslation[service.serviceId] = serviceId;
       }
     } catch (e) {
       const errorMessage = `Could not import your services into our system.\nError: ${e}`;


### PR DESCRIPTION
While working on a [v2](https://github.com/cino/ferdium-server/tree/v2-rebuild) for the ferdium-server I stumbled across this issue.

If you import workspaces that include services it will not be imported correctly due to a mismatch in serviceId translation, in the current situation it is comparing 2 different values to a map.

For example, when we have a workspace with a single service and the service has the following properties: 
```
service.id = 4134
service.serviceId = d61ef2e9-c7d4-4a19-a53f-6cac6ca1a0e8
```

During the import we will discard the serviceId and create a new one, however, the current serviceId is still being mentioned in the workspace data. While importing the workspace it will look for that serviceId and tries to get the newly created version.

The problem is, it is now looking for the old serviceId in a key=>value array where the key is actually the `service.id` thus it will never match.

I hope this makes sense, otherwise, I'll give a better explanation.


