### PR TITLE
Revert "Add a linux/arm64 architecture variant to the official container"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -102,10 +102,9 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
+          # Due to build time, only building the one currently needed.
           # If needed, we can add more platforms when requested.
-          platforms:
-            - linux/amd64
-            - linux/arm64
+          platforms: "linux/amd64"
           # Do not push pull requests
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Reverts ferdium/ferdium-server#46

As per https://github.com/ferdium/ferdium-server/actions/runs/2808565378 the Workflow failed.#46 

@lnhrdt can you please take a look and see what cause this and if you can fix this in a new PR? Maybe try to preview the changes on your local/fork?

Thank you so much!