### PR TITLE
Fix bugs in data import from Ferdium app

### DIFF
--- a/app/Controllers/Http/Dashboard/TransferController.ts
+++ b/app/Controllers/Http/Dashboard/TransferController.ts
@@ -68,12 +68,12 @@ export default class TransferController {
           userId: auth.user?.id,
           serviceId,
           name: service.name,
-          recipeId: service.recipe_id,
+          recipeId: service.recipeId,
           settings: JSON.stringify(service.settings),
         });
 
         // @ts-expect-error Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'
-        serviceIdTranslation[service.service_id] = serviceId;
+        serviceIdTranslation[service.serviceId] = serviceId;
       }
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/app/Controllers/Http/Dashboard/TransferController.ts
+++ b/app/Controllers/Http/Dashboard/TransferController.ts
@@ -68,7 +68,7 @@ export default class TransferController {
           userId: auth.user?.id,
           serviceId,
           name: service.name,
-          recipeId: service.recipeId,
+          recipeId: service.recipe_id || service.recipeId,
           settings:
             typeof service.settings === 'string'
               ? service.settings
@@ -76,7 +76,8 @@ export default class TransferController {
         });
 
         // @ts-expect-error Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'
-        serviceIdTranslation[service.serviceId] = serviceId;
+        serviceIdTranslation[service.service_id || service.serviceId] =
+          serviceId;
       }
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/app/Controllers/Http/Dashboard/TransferController.ts
+++ b/app/Controllers/Http/Dashboard/TransferController.ts
@@ -69,7 +69,10 @@ export default class TransferController {
           serviceId,
           name: service.name,
           recipeId: service.recipeId,
-          settings: JSON.stringify(service.settings),
+          settings:
+            typeof service.settings === 'string'
+              ? service.settings
+              : JSON.stringify(service.settings),
         });
 
         // @ts-expect-error Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'
@@ -109,7 +112,10 @@ export default class TransferController {
           name: workspace.name,
           order: workspace.order,
           services: JSON.stringify(services),
-          data: JSON.stringify(workspace.data),
+          data:
+            typeof workspace.data === 'string'
+              ? workspace.data
+              : JSON.stringify(workspace.data),
         });
       }
     } catch (error) {

--- a/tests/functional/dashboard/import-stubs/services-only.ferdium-data
+++ b/tests/functional/dashboard/import-stubs/services-only.ferdium-data
@@ -9,7 +9,7 @@
       "service_id": "d6901fff-ec44-4251-93de-d7103ed9c44b",
       "name": "random-service-1",
       "recipe_id": "random-service-1",
-      "settings": "{}",
+      "settings": {"isEnabled": true},
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"
     },
@@ -19,7 +19,7 @@
       "service_id": "d6901fff-ec44-4251-93de-d7103ed9c44b",
       "name": "random-service-1",
       "recipe_id": "random-service-1",
-      "settings": "{}",
+      "settings": {"isEnabled": true},
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"
     },
@@ -29,7 +29,7 @@
       "service_id": "d6901fff-ec44-4251-93de-d7103ed9c44b",
       "name": "random-service-1",
       "recipe_id": "random-service-1",
-      "settings": "{}",
+      "settings": {"isEnabled": true},
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"
     }

--- a/tests/functional/dashboard/import-stubs/services-only.ferdium-data
+++ b/tests/functional/dashboard/import-stubs/services-only.ferdium-data
@@ -5,30 +5,30 @@
   "services": [
     {
       "id": 5641,
-      "userId": "1234",
-      "serviceId": "d6901fff-ec44-4251-93de-d7103ed9c44b",
+      "user_id": "1234",
+      "service_id": "d6901fff-ec44-4251-93de-d7103ed9c44b",
       "name": "random-service-1",
-      "recipeId": "random-service-1",
+      "recipe_id": "random-service-1",
       "settings": "{}",
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"
     },
     {
       "id": 2134,
-      "userId": "1234",
-      "serviceId": "d6901fff-ec44-4251-93de-d7103ed9c44b",
+      "user_id": "1234",
+      "service_id": "d6901fff-ec44-4251-93de-d7103ed9c44b",
       "name": "random-service-1",
-      "recipeId": "random-service-1",
+      "recipe_id": "random-service-1",
       "settings": "{}",
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"
     },
     {
       "id": 5343,
-      "userId": "1234",
-      "serviceId": "d6901fff-ec44-4251-93de-d7103ed9c44b",
+      "user_id": "1234",
+      "service_id": "d6901fff-ec44-4251-93de-d7103ed9c44b",
       "name": "random-service-1",
-      "recipeId": "random-service-1",
+      "recipe_id": "random-service-1",
       "settings": "{}",
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"

--- a/tests/functional/dashboard/import-stubs/services-only.json
+++ b/tests/functional/dashboard/import-stubs/services-only.json
@@ -9,7 +9,7 @@
       "serviceId": "d6901fff-ec44-4251-93de-d7103ed9c44b",
       "name": "random-service-1",
       "recipeId": "random-service-1",
-      "settings": "{}",
+      "settings": "{\"isEnabled\":true}",
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"
     },
@@ -19,7 +19,7 @@
       "serviceId": "d6901fff-ec44-4251-93de-d7103ed9c44b",
       "name": "random-service-1",
       "recipeId": "random-service-1",
-      "settings": "{}",
+      "settings": "{\"isEnabled\":true}",
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"
     },
@@ -29,7 +29,7 @@
       "serviceId": "d6901fff-ec44-4251-93de-d7103ed9c44b",
       "name": "random-service-1",
       "recipeId": "random-service-1",
-      "settings": "{}",
+      "settings": "{\"isEnabled\":true}",
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"
     }

--- a/tests/functional/dashboard/import-stubs/services-workspaces.ferdium-data
+++ b/tests/functional/dashboard/import-stubs/services-workspaces.ferdium-data
@@ -5,30 +5,30 @@
   "services": [
     {
       "id": 5641,
-      "userId": "1234",
-      "serviceId": "d6901fff-ec44-4251-93de-d7103ed9c44b",
+      "user_id": "1234",
+      "service_id": "d6901fff-ec44-4251-93de-d7103ed9c44b",
       "name": "random-service-1",
-      "recipeId": "random-service-1",
+      "recipe_id": "random-service-1",
       "settings": "{}",
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"
     },
     {
       "id": 2134,
-      "userId": "1234",
-      "serviceId": "79769de5-a998-4af1-b7d0-89956a15b0ed",
+      "user_id": "1234",
+      "service_id": "79769de5-a998-4af1-b7d0-89956a15b0ed",
       "name": "random-service-2",
-      "recipeId": "random-service-2",
+      "recipe_id": "random-service-2",
       "settings": "{}",
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"
     },
     {
       "id": 5343,
-      "userId": "1234",
-      "serviceId": "0ac973f8-40dc-4760-b2c2-55e1d2943747",
+      "user_id": "1234",
+      "service_id": "0ac973f8-40dc-4760-b2c2-55e1d2943747",
       "name": "random-service-3",
-      "recipeId": "random-service-2",
+      "recipe_id": "random-service-2",
       "settings": "{}",
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"

--- a/tests/functional/dashboard/import-stubs/services-workspaces.ferdium-data
+++ b/tests/functional/dashboard/import-stubs/services-workspaces.ferdium-data
@@ -9,7 +9,7 @@
       "service_id": "d6901fff-ec44-4251-93de-d7103ed9c44b",
       "name": "random-service-1",
       "recipe_id": "random-service-1",
-      "settings": "{}",
+      "settings": {"isEnabled": true},
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"
     },
@@ -19,7 +19,7 @@
       "service_id": "79769de5-a998-4af1-b7d0-89956a15b0ed",
       "name": "random-service-2",
       "recipe_id": "random-service-2",
-      "settings": "{}",
+      "settings": {"isEnabled": true},
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"
     },
@@ -29,7 +29,7 @@
       "service_id": "0ac973f8-40dc-4760-b2c2-55e1d2943747",
       "name": "random-service-3",
       "recipe_id": "random-service-2",
-      "settings": "{}",
+      "settings": {"isEnabled": true},
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"
     }
@@ -39,13 +39,13 @@
       "name": "workspace1",
       "order": 0,
       "services": [],
-      "data": "{\"name\":\"workspace1\"}"
+      "data": {"name":"workspace1"}
     },
     {
       "name": "workspace2",
       "order": 0,
       "services": ["d6901fff-ec44-4251-93de-d7103ed9c44b", "79769de5-a998-4af1-b7d0-89956a15b0ed"],
-      "data": "{\"name\":\"workspace2\"}"
+      "data": {"name":"workspace2"}
     },
     {
       "name": "workspace3",
@@ -55,7 +55,7 @@
         "79769de5-a998-4af1-b7d0-89956a15b0ed",
         "0ac973f8-40dc-4760-b2c2-55e1d2943747"
       ],
-      "data": "{\"name\":\"workspace3\"}"
+      "data": {"name":"workspace3"}
     }
   ]
 }

--- a/tests/functional/dashboard/import-stubs/services-workspaces.json
+++ b/tests/functional/dashboard/import-stubs/services-workspaces.json
@@ -9,7 +9,7 @@
       "serviceId": "d6901fff-ec44-4251-93de-d7103ed9c44b",
       "name": "random-service-1",
       "recipeId": "random-service-1",
-      "settings": "{}",
+      "settings": "{\"isEnabled\":true}",
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"
     },
@@ -19,7 +19,7 @@
       "serviceId": "79769de5-a998-4af1-b7d0-89956a15b0ed",
       "name": "random-service-2",
       "recipeId": "random-service-2",
-      "settings": "{}",
+      "settings": "{\"isEnabled\":true}",
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"
     },
@@ -29,7 +29,7 @@
       "serviceId": "0ac973f8-40dc-4760-b2c2-55e1d2943747",
       "name": "random-service-3",
       "recipeId": "random-service-3",
-      "settings": "{}",
+      "settings": "{\"isEnabled\":true}",
       "created_at": "2022-06-21 08:29:13",
       "updated_at": "2022-07-19 15:47:16"
     }

--- a/tests/functional/dashboard/import-stubs/workspaces-only.ferdium-data
+++ b/tests/functional/dashboard/import-stubs/workspaces-only.ferdium-data
@@ -8,19 +8,19 @@
       "name": "workspace1",
       "order": 0,
       "services": [],
-      "data": "{\"name\":\"workspace1\"}"
+      "data": {"name":"workspace1"}
     },
     {
       "name": "workspace2",
       "order": 0,
       "services": [],
-      "data": "{\"name\":\"workspace2\"}"
+      "data": {"name":"workspace2"}
     },
     {
       "name": "workspace3",
       "order": 0,
       "services": [],
-      "data": "{\"name\":\"workspace3\"}"
+      "data": {"name":"workspace3"}
     }
   ]
 }

--- a/tests/functional/dashboard/transfer.spec.ts
+++ b/tests/functional/dashboard/transfer.spec.ts
@@ -108,6 +108,11 @@ test.group('Dashboard / Transfer page', () => {
       // eslint-disable-next-line no-await-in-loop
       const workspacesForUser = await user.related('workspaces').query();
       assert.equal(workspacesForUser.length, 3);
+
+      // ensure not JSON encoded twice
+      for (const workspace of workspacesForUser) {
+        assert.isNull(workspace.data.match(/\\"/));
+      }
     }
   });
 
@@ -143,6 +148,11 @@ test.group('Dashboard / Transfer page', () => {
       // eslint-disable-next-line no-await-in-loop
       const servicesForUser = await user.related('services').query();
       assert.equal(servicesForUser.length, 3);
+
+      // ensure not JSON encoded twice
+      for (const service of servicesForUser) {
+        assert.isNull(service.settings.match(/\\"/));
+      }
     }
   });
 

--- a/tests/functional/dashboard/transfer.spec.ts
+++ b/tests/functional/dashboard/transfer.spec.ts
@@ -1,4 +1,5 @@
 import { test } from '@japa/runner';
+import { readFileSync } from 'node:fs';
 import UserFactory from 'Database/factories/UserFactory';
 
 test.group('Dashboard / Transfer page', () => {
@@ -19,204 +20,206 @@ test.group('Dashboard / Transfer page', () => {
     response.assertStatus(200);
   });
 
-  // TODO: Fix the following tests
+  test('returns a validation error when not uploading a file', async ({
+    client,
+  }) => {
+    const user = await UserFactory.create();
+    const response = await client.post('/user/transfer').loginAs(user);
 
-  // test('returns a validation error when not uploading a file', async ({
-  //   client,
-  // }) => {
-  //   const user = await UserFactory.create();
-  //   const response = await client.put('/user/transfer').loginAs(user);
+    response.assertTextIncludes('Invalid Ferdium account file');
+  });
 
-  //   response.assertTextIncludes('File missing');
-  // });
+  test('returns a validation error when trying to use anything but json', async ({
+    client,
+  }) => {
+    const user = await UserFactory.create();
+    const response = await client
+      .post('/user/transfer')
+      .loginAs(user)
+      .field(
+        'file',
+        readFileSync('tests/functional/dashboard/import-stubs/random-file.txt'),
+      );
 
-  // test('returns a validation error when trying to use anything but json', async ({
-  //   client,
-  // }) => {
-  //   const user = await UserFactory.create();
-  //   const response = await client
-  //     .put('/user/transfer')
-  //     .loginAs(user)
-  //     .file('file', 'tests/functional/dashboard/import-stubs/random-file.txt', {
-  //       filename: 'random-file.txt',
-  //     });
+    response.assertTextIncludes('Invalid Ferdium account file');
+  });
 
-  //   response.assertTextIncludes('File missing');
-  // });
+  test('returns a validation error when trying to use anything valid json', async ({
+    client,
+  }) => {
+    const user = await UserFactory.create();
+    const response = await client
+      .post('/user/transfer')
+      .loginAs(user)
+      .field(
+        'file',
+        readFileSync('tests/functional/dashboard/import-stubs/invalid.json'),
+      );
 
-  // test('returns a validation error when trying to use anything valid json', async ({
-  //   client,
-  // }) => {
-  //   const user = await UserFactory.create();
-  //   const response = await client
-  //     .put('/user/transfer')
-  //     .loginAs(user)
-  //     .file('file', 'tests/functional/dashboard/import-stubs/invalid.json', {
-  //       filename: 'invalid.json',
-  //     });
+    response.assertTextIncludes('Invalid Ferdium account file');
+  });
 
-  //   response.assertTextIncludes('Invalid Ferdium account file');
-  // });
+  test('returns a validation error when trying to use a json file with no ferdium structure', async ({
+    client,
+  }) => {
+    const user = await UserFactory.create();
+    const response = await client
+      .post('/user/transfer')
+      .loginAs(user)
+      .field(
+        'file',
+        readFileSync(
+          'tests/functional/dashboard/import-stubs/valid-no-data.json',
+        ),
+      );
 
-  // test('returns a validation error when trying to use a json file with no ferdium structure', async ({
-  //   client,
-  // }) => {
-  //   const user = await UserFactory.create();
-  //   const response = await client
-  //     .put('/user/transfer')
-  //     .loginAs(user)
-  //     .file(
-  //       'file',
-  //       'tests/functional/dashboard/import-stubs/valid-no-data.json',
-  //       {
-  //         filename: 'valid-no-data.json',
-  //       },
-  //     );
+    response.assertTextIncludes('Invalid Ferdium account file');
+  });
 
-  //   response.assertTextIncludes('Invalid Ferdium account file (2)');
-  // });
+  test('correctly transfers data from json/ferdi-data and ferdium-data file with only workspaces', async ({
+    client,
+    assert,
+  }) => {
+    // Repeat for all 3 file extension
+    const files = [
+      'workspaces-only.json',
+      'workspaces-only.ferdi-data',
+      'workspaces-only.ferdium-data',
+    ];
 
-  // test('correctly transfers data from json/ferdi-data and ferdium-data file with only workspaces', async ({
-  //   client,
-  //   assert,
-  // }) => {
-  //   // Repeat for all 3 file extension
-  //   const files = [
-  //     'workspaces-only.json',
-  //     'workspaces-only.ferdi-data',
-  //     'workspaces-only.ferdium-data',
-  //   ];
+    for (const file of files) {
+      // eslint-disable-next-line no-await-in-loop
+      const user = await UserFactory.create();
+      // eslint-disable-next-line no-await-in-loop
+      const response = await client
+        .post('/user/transfer')
+        .loginAs(user)
+        .field(
+          'file',
+          readFileSync(`tests/functional/dashboard/import-stubs/${file}`),
+        );
 
-  //   for (const file of files) {
-  //     // eslint-disable-next-line no-await-in-loop
-  //     const user = await UserFactory.create();
-  //     // eslint-disable-next-line no-await-in-loop
-  //     const response = await client
-  //       .put('/user/transfer')
-  //       .loginAs(user)
-  //       .file('file', `tests/functional/dashboard/import-stubs/${file}`, {
-  //         filename: file,
-  //       });
+      response.assertTextIncludes(
+        'Your account has been imported, you can now login as usual!',
+      );
+      // eslint-disable-next-line no-await-in-loop
+      await user.refresh();
 
-  //     response.assertTextIncludes(
-  //       'Your account has been imported, you can now login as usual!',
-  //     );
-  //     // eslint-disable-next-line no-await-in-loop
-  //     await user.refresh();
+      // eslint-disable-next-line no-await-in-loop
+      const workspacesForUser = await user.related('workspaces').query();
+      assert.equal(workspacesForUser.length, 3);
+    }
+  });
 
-  //     // eslint-disable-next-line no-await-in-loop
-  //     const workspacesForUser = await user.related('workspaces').query();
-  //     assert.equal(workspacesForUser.length, 3);
-  //   }
-  // });
+  test('correctly transfers data from json/ferdi-data and ferdium-data file with only services', async ({
+    client,
+    assert,
+  }) => {
+    // Repeat for all 3 file extension
+    const files = [
+      'services-only.json',
+      'services-only.ferdi-data',
+      'services-only.ferdium-data',
+    ];
 
-  // test('correctly transfers data from json/ferdi-data and ferdium-data file with only services', async ({
-  //   client,
-  //   assert,
-  // }) => {
-  //   // Repeat for all 3 file extension
-  //   const files = [
-  //     'services-only.json',
-  //     'services-only.ferdi-data',
-  //     'services-only.ferdium-data',
-  //   ];
+    for (const file of files) {
+      // eslint-disable-next-line no-await-in-loop
+      const user = await UserFactory.create();
+      // eslint-disable-next-line no-await-in-loop
+      const response = await client
+        .post('/user/transfer')
+        .loginAs(user)
+        .field(
+          'file',
+          readFileSync(`tests/functional/dashboard/import-stubs/${file}`),
+        );
 
-  //   for (const file of files) {
-  //     // eslint-disable-next-line no-await-in-loop
-  //     const user = await UserFactory.create();
-  //     // eslint-disable-next-line no-await-in-loop
-  //     const response = await client
-  //       .put('/user/transfer')
-  //       .loginAs(user)
-  //       .file('file', `tests/functional/dashboard/import-stubs/${file}`, {
-  //         filename: file,
-  //       });
+      response.assertTextIncludes(
+        'Your account has been imported, you can now login as usual!',
+      );
+      // eslint-disable-next-line no-await-in-loop
+      await user.refresh();
 
-  //     response.assertTextIncludes(
-  //       'Your account has been imported, you can now login as usual!',
-  //     );
-  //     // eslint-disable-next-line no-await-in-loop
-  //     await user.refresh();
+      // eslint-disable-next-line no-await-in-loop
+      const servicesForUser = await user.related('services').query();
+      assert.equal(servicesForUser.length, 3);
+    }
+  });
 
-  //     // eslint-disable-next-line no-await-in-loop
-  //     const servicesForUser = await user.related('services').query();
-  //     assert.equal(servicesForUser.length, 3);
-  //   }
-  // });
+  test('correctly transfers data from json/ferdi-data and ferdium-data file with workspaces and services', async ({
+    client,
+    assert,
+  }) => {
+    // Repeat for all 3 file extension
+    const files = [
+      'services-workspaces.json',
+      'services-workspaces.ferdi-data',
+      'services-workspaces.ferdium-data',
+    ];
 
-  // test('correctly transfers data from json/ferdi-data and ferdium-data file with workspaces and services', async ({
-  //   client,
-  //   assert,
-  // }) => {
-  //   // Repeat for all 3 file extension
-  //   const files = [
-  //     'services-workspaces.json',
-  //     'services-workspaces.ferdi-data',
-  //     'services-workspaces.ferdium-data',
-  //   ];
+    for (const file of files) {
+      // eslint-disable-next-line no-await-in-loop
+      const user = await UserFactory.create();
+      // eslint-disable-next-line no-await-in-loop
+      const response = await client
+        .post('/user/transfer')
+        .loginAs(user)
+        .field(
+          'file',
+          readFileSync(`tests/functional/dashboard/import-stubs/${file}`),
+        );
 
-  //   for (const file of files) {
-  //     // eslint-disable-next-line no-await-in-loop
-  //     const user = await UserFactory.create();
-  //     // eslint-disable-next-line no-await-in-loop
-  //     const response = await client
-  //       .put('/user/transfer')
-  //       .loginAs(user)
-  //       .file('file', `tests/functional/dashboard/import-stubs/${file}`, {
-  //         filename: file,
-  //       });
+      response.assertTextIncludes(
+        'Your account has been imported, you can now login as usual!',
+      );
+      // eslint-disable-next-line no-await-in-loop
+      await user.refresh();
 
-  //     response.assertTextIncludes(
-  //       'Your account has been imported, you can now login as usual!',
-  //     );
-  //     // eslint-disable-next-line no-await-in-loop
-  //     await user.refresh();
+      // eslint-disable-next-line no-await-in-loop
+      const servicesForUser = await user.related('services').query();
+      // eslint-disable-next-line no-await-in-loop
+      const workspacesForUser = await user.related('workspaces').query();
+      assert.equal(servicesForUser.length, 3);
+      assert.equal(workspacesForUser.length, 3);
 
-  //     // eslint-disable-next-line no-await-in-loop
-  //     const servicesForUser = await user.related('services').query();
-  //     // eslint-disable-next-line no-await-in-loop
-  //     const workspacesForUser = await user.related('workspaces').query();
-  //     assert.equal(servicesForUser.length, 3);
-  //     assert.equal(workspacesForUser.length, 3);
+      const firstServiceUuid = servicesForUser.find(
+        s => s.name === 'random-service-1',
+      )?.serviceId;
+      const secondServiceUuid = servicesForUser.find(
+        s => s.name === 'random-service-2',
+      )?.serviceId;
+      const thirdServiceUUid = servicesForUser.find(
+        s => s.name === 'random-service-3',
+      )?.serviceId;
 
-  //     const firstServiceUuid = servicesForUser.find(
-  //       s => s.name === 'random-service-1',
-  //     )?.serviceId;
-  //     const secondServiceUuid = servicesForUser.find(
-  //       s => s.name === 'random-service-2',
-  //     )?.serviceId;
-  //     const thirdServiceUUid = servicesForUser.find(
-  //       s => s.name === 'random-service-3',
-  //     )?.serviceId;
+      // Assert the first workspace to not have any services
+      const firstWorkspace = workspacesForUser.find(
+        w => w.name === 'workspace1',
+      );
+      if (firstWorkspace?.services) {
+        assert.empty(JSON.parse(firstWorkspace.services));
+      }
 
-  //     // Assert the first workspace to not have any services
-  //     const firstWorkspace = workspacesForUser.find(
-  //       w => w.name === 'workspace1',
-  //     );
-  //     if (firstWorkspace?.services) {
-  //       assert.empty(JSON.parse(firstWorkspace.services));
-  //     }
+      const secondWorkspace = workspacesForUser.find(
+        w => w.name === 'workspace2',
+      );
+      if (secondWorkspace?.services) {
+        assert.deepEqual(JSON.parse(secondWorkspace.services), [
+          firstServiceUuid,
+          secondServiceUuid,
+        ]);
+      }
 
-  //     const secondWorkspace = workspacesForUser.find(
-  //       w => w.name === 'workspace2',
-  //     );
-  //     if (secondWorkspace?.services) {
-  //       assert.deepEqual(JSON.parse(secondWorkspace.services), [
-  //         firstServiceUuid,
-  //         secondServiceUuid,
-  //       ]);
-  //     }
-
-  //     const thirdWorkspace = workspacesForUser.find(
-  //       w => w.name === 'workspace3',
-  //     );
-  //     if (thirdWorkspace?.services) {
-  //       assert.deepEqual(JSON.parse(thirdWorkspace.services), [
-  //         firstServiceUuid,
-  //         secondServiceUuid,
-  //         thirdServiceUUid,
-  //       ]);
-  //     }
-  //   }
-  // });
+      const thirdWorkspace = workspacesForUser.find(
+        w => w.name === 'workspace3',
+      );
+      if (thirdWorkspace?.services) {
+        assert.deepEqual(JSON.parse(thirdWorkspace.services), [
+          firstServiceUuid,
+          secondServiceUuid,
+          thirdServiceUUid,
+        ]);
+      }
+    }
+  });
 });

--- a/tests/functional/dashboard/transfer.spec.ts
+++ b/tests/functional/dashboard/transfer.spec.ts
@@ -107,11 +107,11 @@ test.group('Dashboard / Transfer page', () => {
 
       // eslint-disable-next-line no-await-in-loop
       const workspacesForUser = await user.related('workspaces').query();
-      assert.equal(workspacesForUser.length, 3);
+      assert.equal(workspacesForUser.length, 3, file);
 
       // ensure not JSON encoded twice
       for (const workspace of workspacesForUser) {
-        assert.isNull(workspace.data.match(/\\"/));
+        assert.isNull(workspace.data.match(/\\"/), file);
       }
     }
   });
@@ -147,11 +147,11 @@ test.group('Dashboard / Transfer page', () => {
 
       // eslint-disable-next-line no-await-in-loop
       const servicesForUser = await user.related('services').query();
-      assert.equal(servicesForUser.length, 3);
+      assert.equal(servicesForUser.length, 3, file);
 
       // ensure not JSON encoded twice
       for (const service of servicesForUser) {
-        assert.isNull(service.settings.match(/\\"/));
+        assert.isNull(service.settings.match(/\\"/), file);
       }
     }
   });
@@ -189,8 +189,8 @@ test.group('Dashboard / Transfer page', () => {
       const servicesForUser = await user.related('services').query();
       // eslint-disable-next-line no-await-in-loop
       const workspacesForUser = await user.related('workspaces').query();
-      assert.equal(servicesForUser.length, 3);
-      assert.equal(workspacesForUser.length, 3);
+      assert.equal(servicesForUser.length, 3, file);
+      assert.equal(workspacesForUser.length, 3, file);
 
       const firstServiceUuid = servicesForUser.find(
         s => s.name === 'random-service-1',
@@ -207,28 +207,29 @@ test.group('Dashboard / Transfer page', () => {
         w => w.name === 'workspace1',
       );
       if (firstWorkspace?.services) {
-        assert.empty(JSON.parse(firstWorkspace.services));
+        assert.empty(JSON.parse(firstWorkspace.services), file);
       }
 
       const secondWorkspace = workspacesForUser.find(
         w => w.name === 'workspace2',
       );
       if (secondWorkspace?.services) {
-        assert.deepEqual(JSON.parse(secondWorkspace.services), [
-          firstServiceUuid,
-          secondServiceUuid,
-        ]);
+        assert.deepEqual(
+          JSON.parse(secondWorkspace.services),
+          [firstServiceUuid, secondServiceUuid],
+          file,
+        );
       }
 
       const thirdWorkspace = workspacesForUser.find(
         w => w.name === 'workspace3',
       );
       if (thirdWorkspace?.services) {
-        assert.deepEqual(JSON.parse(thirdWorkspace.services), [
-          firstServiceUuid,
-          secondServiceUuid,
-          thirdServiceUUid,
-        ]);
+        assert.deepEqual(
+          JSON.parse(thirdWorkspace.services),
+          [firstServiceUuid, secondServiceUuid, thirdServiceUUid],
+          file,
+        );
       }
     }
   });


### PR DESCRIPTION
This fixes two issues reported on Discord earlier related to data exported from the Ferdium app not importing correctly.

### 1. NOT NUL constraint failed: `services.recipeId`

Newer versions of the server export data in snake case (i.e `recipe_id`), but all versions of the app-internal server still export it in camel case (i.e. `recipeId`). This currently makes it impossible to migrate from the app server to the API server to share settings between devices.

This PR makes the server accept both snake- and camel camel cased data files.

### 2. Fields containing JSON data might be encoded twice

Newer versions of the server export `services.settings` and `workspaces.data` as plain JSON, while the app-internal servers exports them as strings. This leads to data potentially being JSON encoded twice. 

This PR fixes this by checking the type of these fields and only encoding them when they aren't strings already.

### Tests

Broken tests for the `TransferController` have been fixed and updated with test cases for the two issues above.