### PR TITLE
Force adonis key generation in production

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -59,7 +59,7 @@ print_app_key_message() {
 if [ -z ${APP_KEY} ] && [ ! -f ${key_file} ]
 then
     echo '**** Generating Ferdium-server app key for first run ****'
-    adonis key:generate
+    adonis key:generate --force
     APP_KEY=$(grep APP_KEY .env | cut -d '=' -f2)
     echo ${APP_KEY} > ${key_file}
     print_app_key_message ${APP_KEY}


### PR DESCRIPTION
As per https://github.com/ferdium/ferdium-server/issues/86#issuecomment-1880229802 this PR forces the app key generation for adonis in a production environment.