### PR TITLE
Remove python references and MSVS

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,14 +4,12 @@
   "description": "Ferdium server to replace the default Franz/Ferdi server.",
   "engines": {
     "node": "20.11.0",
-    "pnpm": "8.14.1",
-    "python": "3.12.1"
+    "pnpm": "8.14.1"
   },
   "engine-strict": true,
   "volta": {
     "node": "20.11.0",
-    "pnpm": "8.14.1",
-    "python": "3.12.1"
+    "pnpm": "8.14.1"
   },
   "homepage": "https://github.com/ferdium/ferdium-server",
   "license": "MIT License",
@@ -19,6 +17,7 @@
     "prepare": "is-ci || husky install",
     "dev": "cross-env-shell ENV_PATH=.env.development node ace serve --watch",
     "migrate": "cross-env-shell ENV_PATH=.env.development node ace migration:run",
+    "refresh": "cross-env-shell ENV_PATH=.env.development node ace migration:refresh",
     "status": "cross-env-shell ENV_PATH=.env.development node ace migration:status",
     "build": "node ace build --production",
     "start": "cross-env-shell ENV_PATH=.env node build/server.js",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "description": "Ferdium server to replace the default Franz/Ferdi server.",
   "engines": {
     "node": "20.11.0",
-    "pnpm": "8.14.1"
+    "pnpm": "8.14.1",
+    "python": "3.12.1"
   },
   "engine-strict": true,
   "volta": {
     "node": "20.11.0",
-    "pnpm": "8.14.1"
+    "pnpm": "8.14.1",
+    "python": "3.12.1"
   },
   "homepage": "https://github.com/ferdium/ferdium-server",
   "license": "MIT License",

--- a/scripts/build-unix.sh
+++ b/scripts/build-unix.sh
@@ -3,7 +3,7 @@
 # INTRO:
 # This file is used to build ferdium-server on both x64 and arm-based for macos and linux (not tested on arm for linux).
 # It also handles any corrupted node modules with the 'CLEAN' env var (set it to 'true' for cleaning)
-# It will install the system dependencies except for node (which is still verified)
+# It will install the system dependencies except for node and python (which are still verified)
 # I sometimes symlink my 'recipes' folder so that any changes that I need to do in it can also be committed and pushed independently
 # This file can live anywhere in your PATH
 
@@ -29,6 +29,7 @@ command_exists() {
 #                  Checking the developer environment
 # Check for installed programmes
 command_exists node || fail_with_docs "Node is not installed"
+command_exists python || fail_with_docs "python is not installed"
 
 # Check node version
 EXPECTED_NODE_VERSION=$(cat .nvmrc)
@@ -63,6 +64,17 @@ else
   rm -rf ~/.pnpm-store ~/.pnpm-state
   git -C recipes clean -fxd # Clean recipes folder/submodule
   git clean -fxd            # Note: This will blast away the 'recipes' folder if you have symlinked it
+fi
+
+# -----------------------------------------------------------------------------
+# Ensure that the system dependencies are at the correct version - fail if not
+# Check python version
+EXPECTED_PYTHON_VERSION=$(node -p 'require("./package.json").engines.python')
+ACTUAL_PYTHON_VERSION=$(python --version | sed -e "s/Python //")
+if [[ "$ACTUAL_PYTHON_VERSION" != "$EXPECTED_PYTHON_VERSION" ]]; then
+  fail_with_docs "You are not running the expected version of Python!
+    expected: [$EXPECTED_PYTHON_VERSION]
+    actual  : [$ACTUAL_PYTHON_VERSION]"
 fi
 
 # -----------------------------------------------------------------------------

--- a/scripts/build-unix.sh
+++ b/scripts/build-unix.sh
@@ -3,7 +3,7 @@
 # INTRO:
 # This file is used to build ferdium-server on both x64 and arm-based for macos and linux (not tested on arm for linux).
 # It also handles any corrupted node modules with the 'CLEAN' env var (set it to 'true' for cleaning)
-# It will install the system dependencies except for node and python (which are still verified)
+# It will install the system dependencies except for node (which is still verified)
 # I sometimes symlink my 'recipes' folder so that any changes that I need to do in it can also be committed and pushed independently
 # This file can live anywhere in your PATH
 
@@ -29,7 +29,6 @@ command_exists() {
 #                  Checking the developer environment
 # Check for installed programmes
 command_exists node || fail_with_docs "Node is not installed"
-command_exists python || fail_with_docs "python is not installed"
 
 # Check node version
 EXPECTED_NODE_VERSION=$(cat .nvmrc)
@@ -67,17 +66,6 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# Ensure that the system dependencies are at the correct version - fail if not
-# Check python version
-EXPECTED_PYTHON_VERSION=$(node -p 'require("./package.json").engines.python')
-ACTUAL_PYTHON_VERSION=$(python --version | sed -e "s/Python //")
-if [[ "$ACTUAL_PYTHON_VERSION" != "$EXPECTED_PYTHON_VERSION" ]]; then
-  fail_with_docs "You are not running the expected version of Python!
-    expected: [$EXPECTED_PYTHON_VERSION]
-    actual  : [$ACTUAL_PYTHON_VERSION]"
-fi
-
-# -----------------------------------------------------------------------------
 # Ensure that the system dependencies are at the correct version - recover if not
 # If 'asdf' is installed, reshim for new nodejs if necessary
 command_exists asdf && asdf reshim nodejs
@@ -112,12 +100,11 @@ popd
 pnpm i
 pnpm prepare
 pnpm lint
-# TODO: Uncomment after fixing tests
-# pnpm test
+pnpm test
 
 # -----------------------------------------------------------------------------
-printf "\n*************** Building app ***************\n"
-node ace migration:refresh
-pnpm start --dev
+printf "\n*************** Starting app ***************\n"
+pnpm refresh
+pnpm dev
 
 printf "\n*************** App successfully stopped! ***************\n"

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -1,7 +1,7 @@
 # INTRO:
 # This file is used to build ferdium-server on windows.
 # It also handles any corrupted node modules with the 'CLEAN' env var (set it to 'true' for cleaning)
-# It will install the system dependencies except for node (which is still verified)
+# It will install the system dependencies except for node and python (which are still verified)
 # I sometimes symlink my 'recipes' folder so that any changes that I need to do in it can also be committed and pushed independently
 # This file can live anywhere in your PATH
 

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -37,6 +37,7 @@ Function Test-CommandExists { Param ($command, $1)
 # Check for installed programmes
 Test-CommandExists node "Node is not installed"
 Test-CommandExists npm "npm is not installed"
+Test-CommandExists python "Python is not installed"
 # NEEDS proper way to CHECK MSVS Tools
 
 # Check node version
@@ -89,6 +90,16 @@ if ($env:CLEAN -eq "true")
   git clean -fxd            # Note: This will blast away the 'recipes' folder if you have symlinked it
 }
 
+# -----------------------------------------------------------------------------
+# Ensure that the system dependencies are at the correct version - fail if not
+# Check python version
+$EXPECTED_PYTHON_VERSION = (Get-Content package.json | ConvertFrom-Json).engines.python
+$ACTUAL_PYTHON_VERSION = (python --version).trim("Python ")
+if ([System.Version]$ACTUAL_PYTHON_VERSION -ne [System.Version]$EXPECTED_PYTHON_VERSION) {
+  fail_with_docs "You are not running the expected version of Python!
+    expected: [$EXPECTED_PYTHON_VERSION]
+    actual  : [$ACTUAL_PYTHON_VERSION]"
+}
 # Check pnpm version
 $EXPECTED_PNPM_VERSION = (Get-Content .\recipes\package.json | ConvertFrom-Json).engines.pnpm
 $ACTUAL_PNPM_VERSION = Get-Command pnpm --version -ErrorAction SilentlyContinue  # in case the pnpm executable itself is not present


### PR DESCRIPTION
This PR fixes the build process for the ferdium-server.

I think that python and MSVS are not needed to build the project, therefore I deleted it. But it would be great if anyone test this out!

Thank you!