### PR TITLE
fix: new recipes not created correctly

### DIFF
--- a/app/Controllers/Http/ServiceController.ts
+++ b/app/Controllers/Http/ServiceController.ts
@@ -25,7 +25,7 @@ export default class ServiceController {
 
     // Validate user input
     const data = request.all();
-    
+
     try {
       await request.validate({ schema: createSchema });
     } catch (error) {

--- a/app/Controllers/Http/ServiceController.ts
+++ b/app/Controllers/Http/ServiceController.ts
@@ -24,9 +24,10 @@ export default class ServiceController {
     }
 
     // Validate user input
-    let data;
+    const data = request.all();
+    
     try {
-      data = await request.validate({ schema: createSchema });
+      await request.validate({ schema: createSchema });
     } catch (error) {
       return response.status(401).send({
         message: 'Invalid POST arguments',


### PR DESCRIPTION
When you try to add a new recipe (previously) only `name` and `recipeId` were being taken into consideration. This fixes it.