### PR TITLE
Fix SMTP connection issue by removing incorrect HELO command

### DIFF
--- a/config/mail.ts
+++ b/config/mail.ts
@@ -44,7 +44,6 @@ export default mailConfig({
     */
     smtp: {
       driver: 'smtp',
-      name: Env.get('APP_URL'),
       port: Env.get('SMTP_PORT', '2525'),
       host: Env.get('SMTP_HOST', 'localhost'),
       secure: JSON.parse(Env.get('MAIL_SSL', 'false')),


### PR DESCRIPTION
The Ferdium server is unable to send emails over SMTP on servers that strictly check the HELO message:

```
Couldn't send mail: Error: Can't send mail - all recipients were rejected: 501 5.5.2 <https://ferdium.example.com>: Helo command rejected: Invalid name
```

This issue happens because the APP_URL, used as the HELO name, includes the protocol (`https://`), which should not be part of a HELO message. The HELO command requires a proper domain name without the protocol.

Given that the Ferdium server acts as a sending client and the exact content of the HELO message is not critical (as long as it looks like a domain), we can address this by removing the smtp/name from the SMTP configuration and using the default value.