### PR TITLE
Upgrade all GHA runner OSes to latest stable versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,26 +1,32 @@
-name: AdonisJS check
+name: Builds
 
 on:
+  # Push to any tracked branches
+  push:
+    branches: [main]
+  # PRs only on main branch
   pull_request:
     branches: [main]
+  # Manual trigger from the UI
+  workflow_dispatch:
+    inputs:
+      message:
+        description: 'Message for build'
+        required: true
 
 jobs:
-  adonis-js-check:
+  build:
+    name: Ferdium Server Build
     runs-on: ubuntu-24.04
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-
       - name: Use Node.js specified in the '.nvmrc' file
         uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
-          cache: 'pnpm'
-
+          node-version-file: '.nvmrc'
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
       - name: Install node dependencies recursively
         uses: nick-fields/retry@v3
         with:
@@ -28,15 +34,9 @@ jobs:
           timeout_minutes: 15
           max_attempts: 3
           retry_on: error
-
-      - name: Run typecheck
-        run: pnpm typecheck
-
-      - name: Run linter
-        run: pnpm lint
-
-      - name: Run tests
-        run: pnpm test
-
-      - name: Run build
-        run: pnpm run build
+      - name: Check code style and formatting
+        run: |
+          pnpm typecheck
+          pnpm lint
+          pnpm test
+          pnpm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   adonis-js-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       -
         name: Checkout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Currently, these are the combinations of system dependencies that work for MacOS
 $ jq --null-input '[inputs.engines] | add' < ./package.json < ./recipes/package.json
 {
   "node": "20.18.0",
-  "pnpm": "9.12.0",
+  "pnpm": "9.12.2",
   "python": "3.12.7"
 }
 ```

--- a/package.json
+++ b/package.json
@@ -4,16 +4,16 @@
   "description": "Ferdium server to replace the default Franz/Ferdi server.",
   "engines": {
     "node": "20.18.0",
-    "pnpm": "9.12.0",
+    "pnpm": "9.12.2",
     "python": "3.12.7"
   },
   "engine-strict": true,
   "volta": {
     "node": "20.18.0",
-    "pnpm": "9.12.0",
+    "pnpm": "9.12.2",
     "python": "3.12.7"
   },
-  "packageManager": "pnpm@9.12.0",
+  "packageManager": "pnpm@9.12.2",
   "homepage": "https://github.com/ferdium/ferdium-server",
   "license": "MIT License",
   "scripts": {


### PR DESCRIPTION
Upgraded GHA runners based on the deprecation notice from [this page](https://github.com/actions/runner-images?tab=readme-ov-file#available-images).

Housekeeping
- Upgrade pnpm to 9.12.2
- Fix github workflow file: pnpm command has to be run after node installation
